### PR TITLE
Add `MailcoachMessage` class for use in notification classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-mailcoach-mailer.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-mailcoach-mailer)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-mailcoach-mailer.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-mailcoach-mailer)
 
-[Mailcoach](https://mailcoach.app) is an affordable platform for all things mail. It can send campaigns to list of any size. It also provides flexible email automation to set up drip campaigns and more. 
+[Mailcoach](https://mailcoach.app) is an affordable platform for all things mail. It can send campaigns to list of any size. It also provides flexible email automation to set up drip campaigns and more.
 
-Finally, you can also use Mailcoach to send transactional mails. This package contains a driver so you can send any mailable through Mailcoach. 
+Finally, you can also use Mailcoach to send transactional mails. This package contains a driver so you can send any mailable through Mailcoach.
 
 ```php
 // will be sent through mailcoach
@@ -28,6 +28,16 @@ public function build()
 {
     $this
         ->mailcoachMail('name-of-your-mailcoach-template')
+        ->replacing(['placeholderName' => 'placeHolderValue']);
+}
+```
+
+If you want to send a mail notification using a mailcoach template, you can do that in the following way.
+```php
+public function toMail()
+{
+    return (new MailCoachMessage())
+        ->usingMail('name-of-your-mailcoach-template')
         ->replacing(['placeholderName' => 'placeHolderValue']);
 }
 ```

--- a/src/Notifications/MailcoachMessage.php
+++ b/src/Notifications/MailcoachMessage.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Spatie\MailcoachMailer\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Arr;
+use Spatie\MailcoachMailer\Headers\MailerHeader;
+use Spatie\MailcoachMailer\Headers\ReplacementHeader;
+use Spatie\MailcoachMailer\Headers\TransactionalMailHeader;
+use Symfony\Component\Mime\Email;
+
+class MailcoachMessage extends MailMessage
+{
+    public string $mailName;
+
+    public array $replacements = [];
+
+    public function usingMail(string $mailName): self
+    {
+        $this->mailName = $mailName;
+
+        $this->withSymfonyMessage(function (Email $email) use ($mailName) {
+            $transactionalHeader = new TransactionalMailHeader($mailName);
+
+            if ($email->getHeaders()->has($transactionalHeader->getName())) {
+                $email->getHeaders()->remove($transactionalHeader->getName());
+            }
+
+            $email->getHeaders()->add($transactionalHeader);
+        });
+
+        return $this;
+    }
+
+    public function usingMailer(string $mailer): self
+    {
+        $this->withSymfonyMessage(function (Email $email) use ($mailer) {
+            $mailerHeader = new MailerHeader($mailer);
+
+            if ($email->getHeaders()->has($mailerHeader->getName())) {
+                $email->getHeaders()->remove($mailerHeader->getName());
+            }
+
+            $email->getHeaders()->add($mailerHeader);
+        });
+
+        return $this;
+    }
+
+    public function replacing(array|string $key, string|array|null $value = null): self
+    {
+        if (is_array($key)) {
+            foreach ($key as $realKey => $value) {
+                $this->replacing($realKey, $value);
+            }
+
+            return $this;
+        }
+
+        Arr::set($this->replacements, $key, $value);
+
+        $this->withSymfonyMessage(function (Email $email) use ($key, $value) {
+            $email->getHeaders()->add(new ReplacementHeader($key, $value));
+        });
+
+        return $this;
+    }
+}

--- a/tests/Notifications/MailcoachMessageTest.php
+++ b/tests/Notifications/MailcoachMessageTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Support\Facades\Notification;
+use Spatie\MailcoachMailer\Tests\TestSupport\Notifications\TestNotification;
+
+beforeEach(function () {
+    config()->set('mail.default', 'mailcoach');
+
+    config()->set('mail.mailers.mailcoach', [
+        'transport' => 'mailcoach',
+        'domain' => 'test.mailcoach.app',
+        'token' => 'fake-token',
+    ]);
+});
+
+it('can send a notification that makes use of a mailcoach mail template', function () {
+    expectResponse(function (string $method, string $url, array $options) {
+        expect($url)->toBe('https://test.mailcoach.app/api/transactional-mails/send');
+        expect($method)->toBe('POST');
+
+        expect($options['headers'][1])->toBe('Authorization: Bearer fake-token');
+
+        $body = json_decode($options['body'], true);
+        expect($body['from'])->toBe('from@example.com');
+        expect($body['to'])->toBe('to@example.com');
+        expect($body['mail_name'])->toBe('mail-name');
+
+        expect($body['replacements'])->toBe([
+            'singleName' => 'singleValue',
+            'multipleName' => 'multipleValue',
+        ]);
+    });
+
+    Notification::route('mail', 'to@example.com')->notify(new TestNotification());
+});
+
+it('can send a notification that uses a different mailer', function () {
+    expectResponse(function (string $method, string $url, array $options) {
+        expect($url)->toBe('https://test.mailcoach.app/api/transactional-mails/send');
+        expect($method)->toBe('POST');
+
+        expect($options['headers'][1])->toBe('Authorization: Bearer fake-token');
+
+        $body = json_decode($options['body'], true);
+        expect($body['mailer'])->toBe('transactional-mailer');
+    });
+
+    Notification::route('mail', 'to@example.com')->notify(new TestNotification());
+});
+
+it('can inspect mailcoach message', function () {
+    $mailcoachMessage = (new TestNotification())->toMail();
+
+    expect($mailcoachMessage->mailName)->toBe('mail-name');
+    expect($mailcoachMessage->replacements)->toBe([
+        'singleName' => 'singleValue',
+        'multipleName' => 'multipleValue',
+    ]);
+});

--- a/tests/TestSupport/Notifications/TestNotification.php
+++ b/tests/TestSupport/Notifications/TestNotification.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\MailcoachMailer\Tests\TestSupport\Notifications;
+
+use Illuminate\Notifications\Notification;
+use Spatie\MailcoachMailer\Notifications\MailcoachMessage;
+
+class TestNotification extends Notification
+{
+    public function via() : array
+    {
+        return ['mail'];
+    }
+
+    public function toMail()
+    {
+        return (new MailcoachMessage())
+            ->usingMail('mail-name')
+            ->usingMailer('transactional-mailer')
+            ->replacing('singleName', 'singleValue')
+            ->replacing(['multipleName' => 'multipleValue'])
+            ->from('from@example.com');
+    }
+}


### PR DESCRIPTION
When you want to sent a mail using mailcoach from within a notification class, you have to create a mailable class and call that class from within your notification
```php
class FooNotification extends Notification
{
    public function via()
    {
        return ['mail'];
    }

    public function toMail()
    {
        return new FooMail();
    }
}
```
Having to create a mailable class is a bit annoying. This PR fixes that by allowing you to return a mailcoach message right from within your notification classs.
```php
class FooNotification extends Notification
{
    public function via()
    {
        return ['mail'];
    }

    public function toMail()
    {
        return (new MailcoachMessage())
			->usingMail('mail-template-name')
			->replacing('some-key', 'some-value');
    }
}
```